### PR TITLE
bump version in `jsr.json`

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
     "name": "@paoramen/cheer-reader",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "exports": "./src/index.ts",
     "publish": {
         "exclude": ["test"]


### PR DESCRIPTION
This pull request includes a small change to the `jsr.json` file. The change updates the version number from `0.1.1` to `0.1.2` to reflect the latest release.

* [`jsr.json`](diffhunk://#diff-5193a148ebdd2baf23b4f0a1c1add7ea02a8b92fb022e3a5780e886509d06693L3-R3): Updated version number from `0.1.1` to `0.1.2` to reflect the latest release.